### PR TITLE
Ensure cow is loaded and run at startup in OS X Yosemite

### DIFF
--- a/doc/osx/info.chenyufei.cow.plist
+++ b/doc/osx/info.chenyufei.cow.plist
@@ -13,5 +13,7 @@
       <key>NetworkState</key>
       <true/>
     </dict>
+    <key>RunAtLoad</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
For some reason, cow doesn't start automatically when I upgraded one of my machines to OS X Yosemite.

Adding the `RunAtLoad` section to launch agent plist seems to fix the problem for me.

You may also need to bump the version for the installation script to work.
