### PR TITLE
add support for changing the estimate timeout target

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/cyfdecyf/bufio"
 	"net"
 	"os"
 	"path"
@@ -12,11 +11,15 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cyfdecyf/bufio"
 )
 
 const (
 	version           = "0.9.4"
 	defaultListenAddr = "127.0.0.1:7777"
+	// use a fast to fetch web site
+	defaultEstimateTarget = "www.baidu.com"
 )
 
 type LoadBalanceMode byte
@@ -66,6 +69,9 @@ type Config struct {
 	PrintVer        bool
 	EstimateTimeout bool // if run estimateTimeout()
 
+	// Timeout estimate target site, default to baidu
+	EstimateTarget string
+
 	// not config option
 	saveReqLine bool // for http and cow parent, should save request line from client
 }
@@ -103,6 +109,8 @@ func init() {
 	for _, port := range defaultTunnelAllowedPort {
 		config.TunnelAllowedPort[port] = true
 	}
+
+	config.EstimateTarget = defaultEstimateTarget
 }
 
 // Whether command line options specifies listen addr
@@ -558,6 +566,10 @@ func (p configParser) ParseDialTimeout(val string) {
 
 func (p configParser) ParseDetectSSLErr(val string) {
 	config.DetectSSLErr = parseBool(val, "detectSSLErr")
+}
+
+func (p configParser) ParseEstimateTarget(val string) {
+	config.EstimateTarget = val
 }
 
 // overrideConfig should contain options from command line to override options

--- a/doc/sample-config/rc-en
+++ b/doc/sample-config/rc-en
@@ -145,6 +145,10 @@ listen = http://127.0.0.1:7777
 # Maximum CPU core to use.
 #core = 2
 
+# cow uses this site to estimate timeout, it must be a fast website,
+# default to www.baidu.com
+#EstimateTarget = www.baidu.com
+
 # Ports allowed to create tunnel (HTTP CONNECT method), comma separated list
 # or repeat to append more ports.
 # Ports for the following service are allowed by default:

--- a/estimate_timeout.go
+++ b/estimate_timeout.go
@@ -17,11 +17,8 @@ const maxTimeout = 15 * time.Second
 var dialTimeout = defaultDialTimeout
 var readTimeout = defaultReadTimeout
 
-// use a fast to fetch web site
-const estimateSite = "www.baidu.com"
-
 var estimateReq = []byte("GET / HTTP/1.1\r\n" +
-	"Host: " + estimateSite + "\r\n" +
+	"Host: " + config.EstimateTarget + "\r\n" +
 	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:11.0) Gecko/20100101 Firefox/11.0\r\n" +
 	"Accept: */*\r\n" +
 	"Accept-Language: en-us,en;q=0.5\r\n" +
@@ -32,16 +29,16 @@ var estimateReq = []byte("GET / HTTP/1.1\r\n" +
 // how much time is spent on connect and fetch. This avoids incorrectly
 // considering non-blocked sites as blocked when network connection is bad.
 func estimateTimeout() {
-	// debug.Println("estimating timeout")
+	//debug.Println("estimating timeout")
 	buf := connectBuf.Get()
 	defer connectBuf.Put(buf)
 	var est time.Duration
 
 	start := time.Now()
-	c, err := net.Dial("tcp", estimateSite+":80")
+	c, err := net.Dial("tcp", config.EstimateTarget+":80")
 	if err != nil {
 		errl.Printf("estimateTimeout: can't connect to %s: %v, network has problem?\n",
-			estimateSite, err)
+			config.EstimateTarget, err)
 		goto onErr
 	}
 	defer c.Close()
@@ -71,7 +68,7 @@ func estimateTimeout() {
 	}
 	if err != io.EOF {
 		errl.Printf("estimateTimeout: error getting %s: %v, network has problem?\n",
-			estimateSite, err)
+			config.EstimateTarget, err)
 		goto onErr
 	}
 	est = time.Now().Sub(start) * 10

--- a/http.go
+++ b/http.go
@@ -710,7 +710,7 @@ func parseResponse(sv *serverConn, r *Request, rp *Response) (err error) {
 
 	//Check for http error code from config file
 	if config.HttpErrorCode > 0 && rp.Status == config.HttpErrorCode {
-		errl.Println("Requested http code is raised")
+		debug.Println("Requested http code is raised")
 		return CustomHttpErr
 	}
 


### PR DESCRIPTION
reduce the http error code detection report to debug

The original one was #236 . 
