### PR TITLE
install script: improve detect arm without vfp

### DIFF
--- a/install-cow.sh
+++ b/install-cow.sh
@@ -11,7 +11,14 @@ case $arch in
         arch="32"
         ;;
     "armv5tel" | "armv6l" | "armv7l")
-        arch="-$arch"
+        features=`cat /proc/cpuinfo | grep Features`
+        if [[ ! "$features" =~ "vfp" ]]; then
+            #arm without vfp must use GOARM=5 binary
+            #see https://github.com/golang/go/wiki/GoArm
+            arch="-armv5tel"
+        else
+            arch="-$arch"
+        fi
         ;;
     *)
         echo "$arch currently has no precompiled binary"


### PR DESCRIPTION
在qemu模拟的raspberry pi 上用busybox sh 和bash 测试通过(用到[[ ,似乎和ash和dash不太兼容)。我没有openwrt，没测试上面的sh是否兼容，希望其他人再多测试一下。要是vfp情况比较复杂，是否也可考虑arm全部使用armv5的版本避免运行失败