### PR TITLE
A quick fix to CLOSE_WAIT problem

### DIFF
--- a/http.go
+++ b/http.go
@@ -681,10 +681,9 @@ func parseResponse(sv *serverConn, c *clientConn, r *Request, rp *Response) (err
 				one := make([]byte, 1, 1)
 				if _, err := c.Read(one); err == io.EOF {
 					debug.Printf("read response status line %v %v\n", err, r)
-					debug.Printf("Comet time out\n")
+					errl.Printf("Comet time out\n")
+					c.Conn.Close()
 				}
-				c.Conn.Close()
-				sv.Close()
 			}
 			return err
 		} else {

--- a/http.go
+++ b/http.go
@@ -685,10 +685,8 @@ func parseResponse(sv *serverConn, c *clientConn, r *Request, rp *Response) (err
 				}
 				c.Conn.Close()
 				sv.Close()
-				return err
-			} else {
-				continue
 			}
+			return err
 		} else {
 			break
 		}

--- a/proxy.go
+++ b/proxy.go
@@ -957,7 +957,7 @@ func (sv *serverConn) setReadTimeout(msg string) {
 }
 
 func (sv *serverConn) setCometReadTimeout(msg string) {
-	to := 30 * time.Second
+	to := 60 * time.Second
 	setConnReadTimeout(sv.Conn, to, msg)
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -659,7 +659,7 @@ func (c *clientConn) readResponse(sv *serverConn, r *Request, rp *Response) (err
 		}
 	*/
 
-	if err = parseResponse(sv, r, rp); err != nil {
+	if err = parseResponse(sv, c, r, rp); err != nil {
 		return c.handleServerReadError(r, sv, err, "parse response")
 	}
 	dbgPrintRep(c, r, rp)
@@ -953,6 +953,11 @@ func (sv *serverConn) setReadTimeout(msg string) {
 	} else if sv.siteInfo.AsDirect() {
 		to = maxTimeout
 	}
+	setConnReadTimeout(sv.Conn, to, msg)
+}
+
+func (sv *serverConn) setCometReadTimeout(msg string) {
+	to := 30 * time.Second
 	setConnReadTimeout(sv.Conn, to, msg)
 }
 


### PR DESCRIPTION
Add a deadline to server connection even if it is a reliable connection. Currently set it to 60 seconds. After the timeout, check client connection status and conditionally close the client connection and return error.