### PR TITLE
Opening port for Gtalk

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,6 +36,7 @@ var defaultTunnelAllowedPort = []string{
 	"143", "220", "585", "993", // imap, imap3, imap4-ssl, imaps
 	"109", "110", "473", "995", // pop2, pop3, hybrid-pop, pop3s
 	"5222", "5269", // jabber-client, jabber-server
+	"5223", // Jabber for Google
 	"2401", "3690", "9418", // cvspserver, svn, git
 }
 


### PR DESCRIPTION
Jabber for Google is using port 5223, thought it should be opened by default.