### PR TITLE
解决微信朋友圈图片无法打开的问题

### DIFF
--- a/pac.go
+++ b/pac.go
@@ -116,6 +116,8 @@ function host2Domain(host) {
 function FindProxyForURL(url, host) {
 	if (url.substring(0,4) == "ftp:")
 		return direct;
+	if (host.substring(0,7) == "::ffff:")
+		return direct;
 	if (host.indexOf(".local", host.length - 6) !== -1) {
 		return direct;
 	}


### PR DESCRIPTION
#439 解决微信朋友圈图片不能打开的问题