### PR TITLE
Fix conn reset handling for go 1.6.1

### DIFF
--- a/proxy_unix.go
+++ b/proxy_unix.go
@@ -5,11 +5,12 @@ package main
 import (
 	"net"
 	"syscall"
+	"strings"
 )
 
 func isErrConnReset(err error) bool {
 	if ne, ok := err.(*net.OpError); ok {
-		return ne.Err == syscall.ECONNRESET
+		return strings.Contains(ne.Err.Error(), syscall.ECONNRESET.Error())
 	}
 	return false
 }


### PR DESCRIPTION
When using go 1.6.1, after adding some debug, I find:
ne.Err.Error() is "read: connection reset by peer"
but syscall.ECONNRESET.Error() is "connection reset by peer"

They are not equal, so I make this fix to work around.

Since 0.9.7 build is also built with go 1.6.1, I think it is the root cause causing issue #445 #454