### PR TITLE
Develop: Add a component to record data usage for every user

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -119,7 +119,9 @@ func parseAllowedClient(val string) {
 		auth.allowedClient[i] = netAddr{ip.Mask(mask), mask}
 
 		// TODO: add mask here, add record in usage
-		addAllowedClient(ipAndMask[0])
+		if (usageFlag) {
+			addAllowedClient(ipAndMask[0])
+		}
 	}
 }
 

--- a/auth.go
+++ b/auth.go
@@ -184,7 +184,7 @@ func initAuth() {
 // authentication is needed, and should be passed back on subsequent call.
 func Authenticate(conn *clientConn, r *Request) (err error) {
 	clientIP, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
-	if auth.authed.has(conn.RemoteAddr().String()) {
+	if auth.authed.has(clientIP) {
 		debug.Printf("%s has already authed\n", conn.RemoteAddr().String())
 		return
 	}
@@ -193,9 +193,9 @@ func Authenticate(conn *clientConn, r *Request) (err error) {
 	}
 	err, user := authUserPasswd(conn, r)
 	if err == nil && user != ""{
-		auth.authed.add(conn.RemoteAddr().String())
+		auth.authed.add(clientIP)
 		// update the map of address to userid in usage
-		updateAddrToUser(conn.RemoteAddr().String(), user)
+		updateAddrToUser(clientIP, user)
 
 	}
 	return

--- a/auth.go
+++ b/auth.go
@@ -117,6 +117,9 @@ func parseAllowedClient(val string) {
 			mask = NewNbitIPv4Mask(32)
 		}
 		auth.allowedClient[i] = netAddr{ip.Mask(mask), mask}
+
+		// TODO: add mask here, add record in usage
+		addAllowedClient(ipAndMask[0])
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -76,6 +76,9 @@ type Config struct {
 
 	// not config option
 	saveReqLine bool // for http and cow parent, should save request line from client
+
+	// capacity limitation file
+	UserCapacityFile string
 }
 
 var config Config
@@ -557,6 +560,14 @@ func (p configParser) ParseUserPasswdFile(val string) {
 		Fatal("userPasswdFile:", err)
 	}
 	config.UserPasswdFile = val
+}
+
+func (p configParser) ParseUserCapacityFile(val string) {
+	err := isFileExists(val)
+	if err != nil {
+		Fatal("userCapacityFile:", err)
+	}
+	config.UserCapacityFile = val
 }
 
 func (p configParser) ParseAllowedClient(val string) {

--- a/config.go
+++ b/config.go
@@ -79,6 +79,7 @@ type Config struct {
 
 	// capacity limitation file
 	UserCapacityFile string
+	UsageResetDate int
 }
 
 var config Config
@@ -568,6 +569,10 @@ func (p configParser) ParseUserCapacityFile(val string) {
 		Fatal("userCapacityFile:", err)
 	}
 	config.UserCapacityFile = val
+}
+
+func (p configParser) ParseUsageResetDate(val string) {
+	config.UsageResetDate = parseInt(val, "usageResetDate")
 }
 
 func (p configParser) ParseAllowedClient(val string) {

--- a/doc/sample-config/rc
+++ b/doc/sample-config/rc
@@ -122,7 +122,7 @@ listen = http://127.0.0.1:7777
 # 同时设定该文件的路径
 # 以及自动重置用量的日期
 # 若不需要重置，请将日期设置为-1
-# 如果添加了allowedClient，并且要对其限流，则需要将IP和对应的流量加入到userCapacityFile中
+# 如果添加了allowedClient，并且要对其限流，则需要将IP作为username和对应的流量加入到userCapacityFile中
 # 暂时只支持单个IP的记录
 #userCapacityFile = /path/to/file
 #usageResetDate = 12

--- a/doc/sample-config/rc
+++ b/doc/sample-config/rc
@@ -115,6 +115,16 @@ listen = http://127.0.0.1:7777
 # 注意：如有重复用户，COW 会报错退出
 #userPasswdFile = /path/to/file
 
+# 如需开启用户流量监控，必须使用文件来管理用户名密码， 
+# 同时在另一个文件中设定每个用户的流量，流量为整数，以MB为单位, 每行内容如下
+#   username:capacity
+# 这里的username必须与密码文件中的username对应
+# 同时设定该文件的路径
+# 以及自动重置用量的日期
+# 若不需要重置，请将日期设置为-1
+#userCapacityFile = /path/to/file
+#usageResetDate = 12
+
 # 认证失效时间
 # 语法：2h3m4s 表示 2 小时 3 分钟 4 秒
 #authTimeout = 2h

--- a/doc/sample-config/rc
+++ b/doc/sample-config/rc
@@ -122,6 +122,8 @@ listen = http://127.0.0.1:7777
 # 同时设定该文件的路径
 # 以及自动重置用量的日期
 # 若不需要重置，请将日期设置为-1
+# 如果添加了allowedClient，并且要对其限流，则需要将IP和对应的流量加入到userCapacityFile中
+# 暂时只支持单个IP的记录
 #userCapacityFile = /path/to/file
 #usageResetDate = 12
 

--- a/doc/sample-config/rc-en
+++ b/doc/sample-config/rc-en
@@ -134,6 +134,18 @@ listen = http://127.0.0.1:7777
 # COW will report error and exit if there's duplicated user.
 #userPasswdFile = /path/to/file
 
+# To enable data transfer recording, the userPasswdFile must be enabled.
+# List all those content in another file like this:
+#   username:capacity
+# The username here should match those in userPasswd file.
+# Set the path to the capacity file
+# and usage reset date.
+# Set the reset date to -1 if it is unnecessary.
+# If the allowedClient is enable and their capcity is limited, the IP address(as username) and capacity must been added to userCapacityFile
+# The sub-network is not supported yet.
+#userCapacityFile = /path/to/file
+#usageResetDate = 12
+
 # Time interval to keep authentication information.
 # Syntax: 2h3m4s means 2 hours 3 minutes 4 seconds
 #authTimeout = 2h

--- a/main.go
+++ b/main.go
@@ -41,13 +41,15 @@ func main() {
 
 	initSelfListenAddr()
 	initLog()
+    
+	usageFlag := initUsage()
+
 	initAuth()
 	initSiteStat()
 	initPAC() // initPAC uses siteStat, so must init after site stat
 
 	initStat()
 
-	usageFlag := initUsage()
 
 	initParentPool()
 

--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@ var (
 	relaunch bool
 )
 
+var usageFlag bool
+
 // This code is from goagain
 func lookPath() (argv0 string, err error) {
 	argv0, err = exec.LookPath(os.Args[0])
@@ -29,6 +31,7 @@ func lookPath() (argv0 string, err error) {
 }
 
 func main() {
+	usageFlag = false
 	quit = make(chan struct{})
 	// Parse flags after load config to allow override options in config
 	cmdLineConfig := parseCmdLineConfig()
@@ -42,7 +45,7 @@ func main() {
 	initSelfListenAddr()
 	initLog()
     
-	usageFlag := initUsage()
+	usageFlag = initUsage()
 
 	initAuth()
 	initSiteStat()

--- a/main.go
+++ b/main.go
@@ -47,6 +47,8 @@ func main() {
 
 	initStat()
 
+	usageFlag := initUsage()
+
 	initParentPool()
 
 	/*
@@ -77,6 +79,11 @@ func main() {
 		go proxy.Serve(&wg, quit)
 	}
 
+	//add the usage recorder
+	if usageFlag {
+		wg.Add(1)
+		go startUsageRecorder(&wg, quit)
+	}
 	wg.Wait()
 
 	if relaunch {

--- a/proxy.go
+++ b/proxy.go
@@ -1294,7 +1294,7 @@ func (sv *serverConn) doRequest(c *clientConn, r *Request, rp *Response) (err er
 	if err = c.readResponse(sv, r, rp); err == nil {
 		sv.updateVisit()
 		// response received successfully
-		accumulateUsage(&r, &rp)
+		accumulateUsage(r, rp)
 	}
 	return err
 }

--- a/proxy.go
+++ b/proxy.go
@@ -1038,6 +1038,8 @@ func copyServer2Client(sv *serverConn, c *clientConn, r *Request) (err error) {
 		// set state to rsRecvBody to indicate the request has partial response sent to client
 		r.state = rsRecvBody
 		sv.state = svSendRecvResponse
+		// update usage for user
+		accumulateUsage(c.RemoteAddr().String(), n)
 		if total > directThreshold {
 			sv.updateVisit()
 		}
@@ -1294,7 +1296,7 @@ func (sv *serverConn) doRequest(c *clientConn, r *Request, rp *Response) (err er
 	if err = c.readResponse(sv, r, rp); err == nil {
 		sv.updateVisit()
 		// response received successfully
-		accumulateUsage(c.RemoteAddr().String(), rp)
+		accumulateUsage(c.RemoteAddr().String(), int(rp.ContLen))
 	}
 	return err
 }

--- a/proxy.go
+++ b/proxy.go
@@ -502,7 +502,7 @@ func (c *clientConn) serve() {
 		}
 
 		if config.UserCapacityFile != "" {
-			if checkUsage(&r) != true {
+			if checkUsage(c.RemoteAddr().String()) != true {
 				sendErrorPage(c, statusForbidden, "Run out of capacity",
 					genErrMsg(&r, nil, "Please contact proxy admin."))
 				return
@@ -1294,7 +1294,7 @@ func (sv *serverConn) doRequest(c *clientConn, r *Request, rp *Response) (err er
 	if err = c.readResponse(sv, r, rp); err == nil {
 		sv.updateVisit()
 		// response received successfully
-		accumulateUsage(r, rp)
+		accumulateUsage(c.RemoteAddr().String(), rp)
 	}
 	return err
 }

--- a/proxy.go
+++ b/proxy.go
@@ -501,7 +501,7 @@ func (c *clientConn) serve() {
 			return
 		}
 
-		if config.UserCapacityFile != "" {
+		if usageFlag {
 			if checkUsage(c.RemoteAddr().String()) != true {
 				sendErrorPage(c, statusForbidden, "Run out of capacity",
 					genErrMsg(&r, nil, "Please contact proxy admin."))
@@ -1039,7 +1039,9 @@ func copyServer2Client(sv *serverConn, c *clientConn, r *Request) (err error) {
 		r.state = rsRecvBody
 		sv.state = svSendRecvResponse
 		// update usage for user
-		accumulateUsage(c.RemoteAddr().String(), n)
+		if (usageFlag) {
+			accumulateUsage(c.RemoteAddr().String(), n)
+		}
 		if total > directThreshold {
 			sv.updateVisit()
 		}
@@ -1296,7 +1298,9 @@ func (sv *serverConn) doRequest(c *clientConn, r *Request, rp *Response) (err er
 	if err = c.readResponse(sv, r, rp); err == nil {
 		sv.updateVisit()
 		// response received successfully
-		accumulateUsage(c.RemoteAddr().String(), int(rp.ContLen))
+		if (usageFlag) {
+			accumulateUsage(c.RemoteAddr().String(), int(rp.ContLen))
+		}
 	}
 	return err
 }

--- a/usage.go
+++ b/usage.go
@@ -214,7 +214,8 @@ func accumulateUsage(r *Request, rp *Response) {
 	}
 	userPasswd := strings.Split(arr[1], ":")
 	if len(userPasswd) != 2 {
-		return errors.New("auth: malformed basic auth user:passwd")
+		err := errors.New("auth: malformed basic auth user:passwd")
+		Fatal(err)
 	}
 	user := arr[0]
 	if _, ok := userUsage.usage[user]; ok {

--- a/usage.go
+++ b/usage.go
@@ -178,7 +178,7 @@ func startUsageRecorder(wg *sync.WaitGroup, quit <-chan struct{}) {
 		if exit {
 			break
 		}
-		if interval > 7200 {
+		if interval > 1800 {
 			flushLog()
 			interval = 0
 		}

--- a/usage.go
+++ b/usage.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"github.com/cyfdecyf/bufio"
+	"errors"
+	"time"
+	"bytes"
+	"fmt"
+)
+
+var userUsage struct {
+	usage map[string]int
+	capacity map[string]int
+	lastSavedts time.Time
+}
+
+func parseCapacity(line string) (user string, capacity int, err error) {
+	arr := strings.Split(line, ":")
+	n := len(arr)
+	if n != 2 {
+		err = errors.New("User capacity limitation: " + line +
+		" syntax wrong, should be username:capacity")
+		return
+	}
+	u, c := arr[0], uint32(arr[1])
+	return u, c, nil
+}
+
+func parseUsage(line string) (user string, usage int, err error) {
+	arr := strings.Split(line, ":")
+	n := len(arr)
+	if n != 2 {
+		err = errors.New("Record file format error: " + line +
+		" syntax wrong, should be username:usage")
+		return
+	}
+	u, c := arr[0], uint32(arr[1])
+	return u, c, nil
+}
+
+func loadCapcity(file string) {
+	// load capcity first
+	if file == "" {
+		return
+	}
+	f, err := os.Open(file)
+	if err != nil {
+		Fatal("error opening user usage file:", err)
+	}
+
+	r := bufio.NewReader(f)
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		line := s.Text()
+		if line == "" {
+			continue
+		}
+		u, c, err := parseCapacity(s.Text())
+		if err != nil {
+			Fatal(err)
+		}
+		if _, ok := userUsage.capacity[u]; ok {
+			Fatal("duplicate user:", u)
+		}
+		userUsage.capacity[u] = c
+		userUsage.usage[u] = 0
+
+	}
+	f.Close()
+}
+
+func loadUsage() {
+	dir, err := os.Getwd()
+	if err != nil {
+		Fatal("error opening current directory:", err)
+	}
+	buf := new(bytes.Buffer)
+	fmt.Fprint(buf, dir, "/_records.log")
+	f, err := os.OpenFile(buf.String(), os.O_CREATE, 0666)
+	if err != nil {
+		Fatal("error opening/creating user record file:", err)
+	}
+	r := bufio.NewReader(f)
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		line := s.Text()
+		if line == "" {
+			continue
+		}
+		u, c, err := parseUsage(s.Text())
+		if err != nil {
+			Fatal(err)
+		}
+		if _, ok := userUsage.usage[u]; ok {
+			Fatal("duplicate record:", line)
+		}
+		userUsage.usage[u] = c
+
+	}
+	f.Close()
+}
+
+func loadUserUsageFile(file string) {
+	//load capacity at first
+	loadCapcity(file)
+
+	// load usage
+	loadUsage()
+}
+
+

--- a/usage.go
+++ b/usage.go
@@ -3,12 +3,16 @@ package main
 import (
 	"os"
 	"strings"
+	"strconv"
 	"github.com/cyfdecyf/bufio"
 	"errors"
 	"time"
 	"bytes"
 	"fmt"
+	"sync"
 )
+
+var recordPath string
 
 var userUsage struct {
 	usage map[string]int
@@ -22,10 +26,16 @@ func parseCapacity(line string) (user string, capacity int, err error) {
 	if n != 2 {
 		err = errors.New("User capacity limitation: " + line +
 		" syntax wrong, should be username:capacity")
-		return
+		return "", 0, err
 	}
-	u, c := arr[0], uint32(arr[1])
-	return u, c, nil
+	c, err := strconv.Atoi(arr[1])
+	if err != nil {
+		err = errors.New("Record file format error: " + arr[1] +
+		" syntax wrong, should be int")
+		return "", 0, err
+	}
+	debug.Printf("user: %s, capacity: %d", arr[0], c)
+	return arr[0], c, nil
 }
 
 func parseUsage(line string) (user string, usage int, err error) {
@@ -34,10 +44,16 @@ func parseUsage(line string) (user string, usage int, err error) {
 	if n != 2 {
 		err = errors.New("Record file format error: " + line +
 		" syntax wrong, should be username:usage")
-		return
+		return "", 0, err
 	}
-	u, c := arr[0], uint32(arr[1])
-	return u, c, nil
+	c, err := strconv.Atoi(arr[1])
+	if err != nil {
+		err = errors.New("Record file format error: " + arr[1] +
+		" syntax wrong, should be int")
+		return "", 0, err
+	}
+	debug.Printf("user: %s, usage: %d", arr[0], c)
+	return arr[0], c, nil
 }
 
 func loadCapcity(file string) {
@@ -72,13 +88,7 @@ func loadCapcity(file string) {
 }
 
 func loadUsage() {
-	dir, err := os.Getwd()
-	if err != nil {
-		Fatal("error opening current directory:", err)
-	}
-	buf := new(bytes.Buffer)
-	fmt.Fprint(buf, dir, "/_records.log")
-	f, err := os.OpenFile(buf.String(), os.O_CREATE, 0666)
+	f, err := os.OpenFile(recordPath, os.O_CREATE, 0600)
 	if err != nil {
 		Fatal("error opening/creating user record file:", err)
 	}
@@ -102,12 +112,76 @@ func loadUsage() {
 	f.Close()
 }
 
-func loadUserUsageFile(file string) {
+func flushLog() {
+	bakPath := recordPath + ".bak"
+	f, err := os.OpenFile(bakPath, os.O_WRONLY | os.O_CREATE, 0600)
+	if err != nil {
+		Fatal("error opening/creating user record file:", err)
+	}
+	w := bufio.NewWriter(f)
+	for k, v := range userUsage.usage {
+		r := fmt.Sprintf("%s:%d\n", k, v)
+		w.WriteString(r)
+	}
+	w.Flush()
+	f.Close()
+
+	os.Remove(recordPath)
+	os.Rename(bakPath, recordPath)
+
+
+}
+
+func startUsageRecorder(wg *sync.WaitGroup, quit <-chan struct{}) {
+	defer func() {
+		flushLog()
+		debug.Println("exit the usage recorder")
+		wg.Done()
+	}()
+	var exit bool
+	go func() {
+		<-quit
+		exit=true
+	}()
+
+	debug.Println("start usage recording!")
+	interval := 0
+	for {
+		time.Sleep(1000 * time.Millisecond)
+		interval += 1
+		if exit {
+			break
+		}
+		if interval > 7200 {
+			flushLog()
+			interval = 0
+		}
+	}
+}
+
+func initUsage() bool{
+	if config.UserPasswdFile == "" ||
+		config.UserCapacityFile == "" {
+		return false
+	}
+	// get current running path
+	dir, err := os.Getwd()
+	if err != nil {
+		Fatal("error opening current directory:", err)
+	}
+	buf := new(bytes.Buffer)
+	fmt.Fprint(buf, dir, "/_records.log")
+	recordPath = buf.String()
+
+	userUsage.capacity = make(map[string]int)
+	userUsage.usage = make(map[string]int)
+	userUsage.lastSavedts = time.Now()
 	//load capacity at first
-	loadCapcity(file)
+	loadCapcity(config.UserCapacityFile)
 
 	// load usage
 	loadUsage()
+	return true
 }
 
 

--- a/usage.go
+++ b/usage.go
@@ -184,4 +184,44 @@ func initUsage() bool{
 	return true
 }
 
+func checkUsage(r *Request) bool {
+	arr := strings.SplitN(r.ProxyAuthorization, " ", 2)
+	if len(arr) != 2 {
+		err := errors.New("auth: malformed ProxyAuthorization header: " + r.ProxyAuthorization)
+		Fatal(err)
+	}
+	userPasswd := strings.Split(arr[1], ":")
+	if len(userPasswd) != 2 {
+		err := errors.New("auth: malformed basic auth user:passwd")
+		Fatal(err)
+	}
+	user := arr[0]
+	var capacity int
+	var usage int
+	if val, ok := userUsage.capacity[user]; ok {
+		capacity = val
+	}
+	// don't have to check here
+	usage = userUsage.usage[user]
+	return (usage > capacity)
+}
+
+func accumulateUsage(r *Request, rp *Response) {
+	arr := strings.SplitN(r.ProxyAuthorization, " ", 2)
+	if len(arr) != 2 {
+		err := errors.New("auth: malformed ProxyAuthorization header: " + r.ProxyAuthorization)
+		Fatal(err)
+	}
+	userPasswd := strings.Split(arr[1], ":")
+	if len(userPasswd) != 2 {
+		return errors.New("auth: malformed basic auth user:passwd")
+	}
+	user := arr[0]
+	if _, ok := userUsage.usage[user]; ok {
+		userUsage.usage[user] += len(rp.rawByte) / 1024 / 1024
+	}
+
+
+}
+
 

--- a/usage.go
+++ b/usage.go
@@ -268,5 +268,5 @@ func addAllowedClient(addr string) {
 		return
 	}
 
-	userUsage[addr] = addr
+	userUsage.addrToUser[addr] = addr
 }

--- a/usage.go
+++ b/usage.go
@@ -262,3 +262,11 @@ func updateAddrToUser(addr string, user string)  {
 	debug.Println("add addr: ", addr, "to user: ", user)
 }
 
+func addAllowedClient(addr string) {
+	if _, ok := userUsage.addrToUser[addr]; ok {
+		debug.Println("duplicated allowed client ip: ", addr)
+		return
+	}
+
+	userUsage[addr] = addr
+}

--- a/usage.go
+++ b/usage.go
@@ -103,9 +103,6 @@ func loadUsage() {
 		if err != nil {
 			Fatal(err)
 		}
-		if _, ok := userUsage.usage[u]; ok {
-			Fatal("duplicate record:", line)
-		}
 		userUsage.usage[u] = c
 
 	}
@@ -220,6 +217,7 @@ func accumulateUsage(r *Request, rp *Response) {
 	user := arr[0]
 	if _, ok := userUsage.usage[user]; ok {
 		userUsage.usage[user] += len(rp.rawByte) / 1024 / 1024
+		debug.Printf("user: %s add %d MB, total %d", user, len(rp.rawByte) / 1024 / 1024, userUsage.usage[user])
 	}
 
 


### PR DESCRIPTION
In order to support multiple users to use the COW proxy without running out of the capacity of VPS by a few, I add a component to limit the usage of every user.

The major addition is **usage.go**.
- **Configuration:** A new component to do usage recording. The limitation of every user is set in a file named _userCapacityFile_ (more detail in doc/sample-config/rc). It's loaded when the COW starts. The _userPasswdFile_ must been enabled to use the recording. See more details in _doc/sample-config/rc_ . 
- **Limitation Check:** The limitation check is triggered after _**Authenticate**_ in **proxy.go** . Error page is returned if the capacity is run out of.
- **Recording:** To record the usage, the _**accumulatedUsage**_ is called for every HTTP response ( _**doRequest**_ in **proxy.go**) and every HTTP CONNECT (_**copyServer2Client**_ in **proxy.go**). The current usage is first loaded from _cowDir/_record.log_ if existed. A background thread flush the in-memory record to the disk file every half hour. The record will be reset on every reset date (more detail in doc/sample-config/rc).
