### PR TITLE
Cow internal automatic application autoproxy.pac rules to proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.sublime*
 cow-proxy
 bin
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - go get github.com/cyfdecyf/bufio
   - go get github.com/cyfdecyf/leakybuf
   - go get github.com/cyfdecyf/color
+  - go get github.com/jackwakefield/gopac
 script:
   - pushd $TRAVIS_BUILD_DIR
   - go test -v

--- a/config.go
+++ b/config.go
@@ -64,10 +64,11 @@ type Config struct {
 
 	HttpErrorCode int
 
-	dir         string // directory containing config file
-	StatFile    string // Path for stat file
-	BlockedFile string // blocked sites specified by user
-	DirectFile  string // direct sites specified by user
+	dir           string // directory containing config file
+	StatFile      string // Path for stat file
+	BlockedFile   string // blocked sites specified by user
+	DirectFile    string // direct sites specified by user
+	AutoProxyFile string // used pac file
 
 	// not configurable in config file
 	PrintVer        bool
@@ -90,6 +91,7 @@ func initConfig(rcFile string) {
 	config.BlockedFile = path.Join(config.dir, blockedFname)
 	config.DirectFile = path.Join(config.dir, directFname)
 	config.StatFile = path.Join(config.dir, statFname)
+	config.AutoProxyFile = path.Join(config.dir, autoProxyFname)
 
 	config.DetectSSLErr = false
 	config.AlwaysProxy = false
@@ -472,6 +474,13 @@ func (p configParser) ParseDirectFile(val string) {
 	config.DirectFile = expandTilde(val)
 	if err := isFileExists(config.DirectFile); err != nil {
 		Fatal("direct file:", err)
+	}
+}
+
+func (p configParser) ParsePacFile(val string) {
+	config.AutoProxyFile = expandTilde(val)
+	if err := isFileExists(config.AutoProxyFile); err != nil {
+		Fatal("autoproxy file:", err)
 	}
 }
 

--- a/config_unix.go
+++ b/config_unix.go
@@ -7,10 +7,11 @@ import (
 )
 
 const (
-	rcFname      = "rc"
-	blockedFname = "blocked"
-	directFname  = "direct"
-	statFname    = "stat"
+	rcFname        = "rc"
+	blockedFname   = "blocked"
+	directFname    = "direct"
+	statFname      = "stat"
+	autoProxyFname = "autoproxy.pac"
 
 	newLine = "\n"
 )

--- a/config_windows.go
+++ b/config_windows.go
@@ -6,10 +6,11 @@ import (
 )
 
 const (
-	rcFname      = "rc.txt"
-	blockedFname = "blocked.txt"
-	directFname  = "direct.txt"
-	statFname    = "stat.txt"
+	rcFname        = "rc.txt"
+	blockedFname   = "blocked.txt"
+	directFname    = "direct.txt"
+	statFname      = "stat.txt"
+	autoProxyFname = "autoproxy.pac"
 
 	newLine = "\r\n"
 )

--- a/doc/sample-config/rc
+++ b/doc/sample-config/rc
@@ -151,8 +151,14 @@ listen = http://127.0.0.1:7777
 # 可能将可直连网站误判为被墙网站，当 GFW 进行 SSL 中间人攻击时可以考虑使用
 #detectSSLErr = false
 
-# 修改 stat/blocked/direct 文件路径，如不指定，默认在配置文件所在目录下
+# 修改 stat/blocked/direct/autoproxy.pac 文件路径，如不指定，默认在配置文件所在目录下
+# autoproxy.pac会被优先作用
+# 可以使用genpac生成pac文件，可以直接用于linux终端 export http_proxy=path; export https_proxy=$http_proxy，并同时工作在内外网的情况
+# genpac --format=pac --pac-proxy="SOCKS5 127.0.0.1:1080" \
+#   --gfwlist-url="https://raw.githubusercontent.com/gfwlist/gfwlist/master/gfwlist.txt" \
+#   [--user-rule-from=$HOME/user-rules.txt] -o $HOME/.cow/autoproxy.pac
 # 执行 cow 的用户需要有对 stat 文件所在目录的写权限才能更新 stat 文件
 #statFile = <dir to rc file>/stat
 #blockedFile = <dir to rc file>/blocked
 #directFile = <dir to rc file>/direct
+#pacFile = <dir to rc file>/autoproxy.pac

--- a/doc/sample-config/rc-en
+++ b/doc/sample-config/rc-en
@@ -176,10 +176,11 @@ listen = http://127.0.0.1:7777
 # Only consider this option when GFW is making middle man attack.
 #detectSSLErr = false
 
-# Change the stat/blocked/direct file position, defaults to files under directory
+# Change the stat/blocked/direct/autoproxy.pac file position, defaults to files under directory
 # containing rc file.
 # The cow user must write access to directory containing the stat file in order
 # to update stat.
 #statFile = <dir to rc file>/stat
 #blockedFile = <dir to rc file>/blocked
 #directFile = <dir to rc file>/direct
+#pacFile = <dir to rc file>/autoproxy.pac


### PR DESCRIPTION
linux下直接使用export https_proxy=http://ip:port/; export http_proxy=$https_proxy在涉及到内外网操作的时候希望和本地的autoproxy.pac上行为一致，内部增加了优先pac配置内容的判断